### PR TITLE
Avoid writing builtins.str to redis on py2

### DIFF
--- a/blingalytics/caches/redis_cache.py
+++ b/blingalytics/caches/redis_cache.py
@@ -13,8 +13,7 @@ a simple dev environment.
 from __future__ import absolute_import
 from builtins import map
 from builtins import zip
-from builtins import str
-from past.builtins import long
+from past.builtins import long, unicode
 
 from datetime import datetime
 from decimal import Decimal
@@ -84,7 +83,7 @@ class RedisCache(caches.Cache):
                 data = {}
                 for name, value in list(row.items()):
                     t = type(value)
-                    if t is str:
+                    if t is unicode:
                         data[name] = value.encode('utf-8')
                     elif t is Decimal:
                         data[name] = float(value)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ open-source project. Blingalytics is released under the `MIT License`_.
 
 setup(
     name='Blingalytics',
-    version='v0.2.0chownow',
+    version='v0.2.1chownow',
     author='Jeff Schenck',
     author_email='jmschenck@gmail.com',
     url='http://github.com/jeffschenck/blingalytics',


### PR DESCRIPTION
https://github.com/ChowNow/blingalytics/blob/7b8ebe6b904a0a5739cee5d8c0fd91ebca7dece3/blingalytics/caches/redis_cache.py#L84-L94

In line 93, we cast the value to `builtins.str`. The Redis library doesn't recognize the `builtins.str` type, so attempting to write a value of this type to Redis raises a `ResponseError: ERR Protocol error: unbalanced quotes in request` on py2. This error doesn't get raised on py3 because on py3, `builtins.str` is an alias to py3's default `str` type. 

This issue may have been fixed in later versions of Redis. 
